### PR TITLE
Rename Component with Layout in the docs

### DIFF
--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -5,35 +5,29 @@ import { createMachineComponent } from "@webinargeek/machine-component"
 
 const Count = createMachineComponent<CountMachine>({
   states: {
-    a: {
-      Component: ({ actorRef }) => {
-        const count = useSelector(actorRef, (state) => state.context.count)
+    a: ({ actorRef }) => {
+      const count = useSelector(actorRef, (state) => state.context.count)
 
-        return (
-          <>
-            <div className="card">
-              <button onClick={() => actorRef.send({ type: "count" })}>
-                count is {count}
-              </button>
-            </div>
-            <div className="card">
-              <button onClick={() => actorRef.send({ type: "stop" })}>
-                Stop
-              </button>
-            </div>
-          </>
-        )
-      },
+      return (
+        <>
+          <div className="card">
+            <button onClick={() => actorRef.send({ type: "count" })}>
+              count is {count}
+            </button>
+          </div>
+          <div className="card">
+            <button onClick={() => actorRef.send({ type: "stop" })}>
+              Stop
+            </button>
+          </div>
+        </>
+      )
     },
-    b: {
-      Component: ({ actorRef }) => (
-        <div className="card">
-          <button onClick={() => actorRef.send({ type: "start" })}>
-            Start
-          </button>
-        </div>
-      ),
-    },
+    b: ({ actorRef }) => (
+      <div className="card">
+        <button onClick={() => actorRef.send({ type: "start" })}>Start</button>
+      </div>
+    ),
   },
 })
 

--- a/packages/machine-component/README.md
+++ b/packages/machine-component/README.md
@@ -88,7 +88,7 @@ const App = () => {
 
 ### Layout components
 
-A Component can be passed to the `Component` field of a parent state which will be rendered without being unmounted as the child states change.
+A component can be passed to the `Layout` field of a parent state which will be rendered without being unmounted as the child states change.
 
 The components defined in the child states will be passed into the `children` prop.
 
@@ -96,7 +96,7 @@ The components defined in the child states will be passed into the `children` pr
 const Component = createMachineComponent<MyMachine>({
   states: {
     a: {
-      Component: () => <div>A {children}</div>,
+      Layout: ({ children }) => <div>A {children}</div>,
       states: {
         b: () => <div>B</div>,
         c: () => <div>C</div>,
@@ -117,7 +117,7 @@ The state components will also receive the `actorRef` prop that was passed to th
 const Component = createMachineComponent<MyMachine, { foo: string }>({
   states: {
     a: {
-      Component: ({ foo }) => <div>A {foo}</div>,
+      Layout: ({ foo }) => <div>A {foo}</div>,
     },
     b: ({ foo }) => <div>B {foo}</div>,
     c: ({ children, actorRef }) => {


### PR DESCRIPTION
I renamed a property in the docs and fixed the example.

I also saw that the _rules of hook_ ESLint's plugin doesn't like defining components with arrow functions like so. This is now a recommended ESLint rule, so I'm wondering if it wouldn't trigger an error for most developers who could use this library. We might want to document the problem and suggest a workaround.

![CleanShot 2025-01-11 at 20 34 03@2x](https://github.com/user-attachments/assets/90b212fb-a52d-4308-bc8d-1d6e0e4153a8)
